### PR TITLE
Searchbar on the bottom

### DIFF
--- a/app/src/main/java/com/anpmech/launcher/LaunchableAdapter.java
+++ b/app/src/main/java/com/anpmech/launcher/LaunchableAdapter.java
@@ -794,7 +794,9 @@ public class LaunchableAdapter<T extends LaunchableActivity> extends BaseAdapter
             }
 
             sort(PIN_TO_TOP);
-
+            if (prefs.isSearchBarOnBottom()) {
+                Collections.reverse(mObjects);
+            }
             if (notify) {
                 notifyDataSetChanged();
             }

--- a/app/src/main/java/com/anpmech/launcher/activities/SharedLauncherPrefs.java
+++ b/app/src/main/java/com/anpmech/launcher/activities/SharedLauncherPrefs.java
@@ -250,4 +250,8 @@ public class SharedLauncherPrefs {
     public boolean isRotationAllowed() {
         return isPrefEnabled(R.string.pref_key_allow_rotation, true);
     }
+
+    public boolean isSearchBarOnBottom() {
+        return isPrefEnabled(R.string.pref_searchbar_on_bottom, false);
+    }
 }

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -17,19 +17,54 @@
   ~ Warning: Padding for the masterLayout and the appContainer are set dynamically and will be
   ~ overwritten. See SearchActivity.java#setupPadding().
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/masterLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_marginLeft="@dimen/activity_horizontal_margin"
     android:layout_marginTop="@dimen/activity_vertical_margin"
-    android:layout_marginRight="@dimen/activity_horizontal_margin"
-    android:orientation="vertical">
+    android:layout_marginRight="@dimen/activity_horizontal_margin">
+
+    <GridView
+        android:id="@+id/appsContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:choiceMode="singleChoice"
+        android:clipToPadding="false"
+        android:columnWidth="@dimen/app_row_column_width"
+        android:fadingEdge="none"
+        android:horizontalSpacing="@dimen/app_row_horizontal_spacing"
+        android:numColumns="auto_fit"
+        android:overScrollMode="never"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:scrollbars="none"
+        android:stackFromBottom="true"
+        android:stretchMode="spacingWidth"
+        android:verticalSpacing="@dimen/app_row_vertical_spacing" >
+
+    </GridView>
+
+    <!--
+      ~ Bug:
+      ~
+      ~ If enabled, overscroll mode fails on the bottom, if a navigation bar exists. This bug
+      ~ exists due to the following:
+      ~
+      ~ * The application container has focus and won't scroll to another view.
+      ~
+      ~ * If a ScrollView is added outside the GridView, it then takes the focus, and the
+      ~ overscroll.
+      ~
+      ~ This could also be fixed by not allowing scrolling under the navigation bar; I
+      ~ consider disabling overscroll to be the better compromise.
+    -->
 
     <LinearLayout
         android:id="@+id/customActionBar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="@dimen/actionbar_height"
+        android:layout_gravity="top"
         android:background="@drawable/search_box_bg">
 
         <ImageButton
@@ -49,7 +84,6 @@
             android:background="@null"
             android:ellipsize="end"
             android:hint="@string/search_view_hint"
-            android:imeActionId="@+id/actionGo"
             android:imeActionLabel="@string/launch"
             android:imeOptions="actionGo"
             android:inputType="text"
@@ -58,11 +92,6 @@
             android:textColor="@android:color/black"
             android:textColorHint="@color/text_hint_grey"
             android:textSize="18sp" />
-
-        <View
-            android:id="@+id/overflow_button_topleft"
-            android:layout_width="0dp"
-            android:layout_height="0dp" />
 
         <ImageButton
             android:id="@+id/clear_button"
@@ -88,35 +117,11 @@
             android:padding="@dimen/actionbar_icon_padding"
             android:src="@drawable/ic_more_vert_white_24dp"
             android:tint="@color/hint_grey" />
+
+        <View
+            android:id="@+id/overflow_button_topleft"
+            android:layout_width="0dp"
+            android:layout_height="0dp" />
     </LinearLayout>
 
-    <!--
-      ~ Bug:
-      ~
-      ~ If enabled, overscroll mode fails on the bottom, if a navigation bar exists. This bug
-      ~ exists due to the following:
-      ~
-      ~ * The application container has focus and won't scroll to another view.
-      ~
-      ~ * If a ScrollView is added outside the GridView, it then takes the focus, and the
-      ~ overscroll.
-      ~
-      ~ This could also be fixed by not allowing scrolling under the navigation bar; I
-      ~ consider disabling overscroll to be the better compromise.
-    -->
-    <GridView
-        android:id="@+id/appsContainer"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:choiceMode="singleChoice"
-        android:clipToPadding="false"
-        android:columnWidth="@dimen/app_row_column_width"
-        android:fadingEdge="none"
-        android:horizontalSpacing="@dimen/app_row_horizontal_spacing"
-        android:numColumns="auto_fit"
-        android:overScrollMode="never"
-        android:paddingTop="@dimen/activity_vertical_margin"
-        android:scrollbars="none"
-        android:stretchMode="spacingWidth"
-        android:verticalSpacing="@dimen/app_row_vertical_spacing" />
-</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -15,10 +15,12 @@
 
 <resources>
     <dimen name="actionbar_icon_padding">10dp</dimen>
+    <dimen name="actionbar_height">60dp</dimen>
+    <dimen name="actionbar_top_margin">5dp</dimen>
 
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">0dp</dimen>
 
     <!-- This anchors the text right below the app_icon_size.  -->
     <dimen name="app_text_upper_margin">60dp</dimen>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -69,4 +69,7 @@
 
     <!-- This string is a possible value for ordering launchables by frequency of usage. -->
     <string name="pref_value_preferred_order_usage" translatable="false">usage</string>
+
+    <!-- This string indicates if the search bar should be on the bottom of the screen. -->
+    <string name="pref_searchbar_on_bottom" translatable="false">searchbar_on_bottom</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="pref_app_preferred_order_entries_usages">Most used first</string>
     <string name="action_set_wallpaper">Set wallpaper</string>
     <string name="pref_allow_rotation">Allow orientation change</string>
+    <string name="settings_searchbar_on_bottom">Searchbar on bottom</string>
 
     <string name="pref_modify_android_usage_title">Set Android usage statistics support</string>
     <string name="pref_modify_android_usage_summary">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -13,7 +13,8 @@
   ~ limitations under the License.
   -->
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory
         android:key="pref_category_general"
         android:title="@string/settings_category_general_category">
@@ -36,6 +37,13 @@
             android:defaultValue="true"
             android:key="pref_allow_rotation"
             android:title="@string/pref_allow_rotation" />
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="@string/pref_searchbar_on_bottom"
+            android:title="@string/settings_searchbar_on_bottom"
+            tools:text="@string/settings_searchbar_on_bottom" />
         <Preference
             android:key="modify_usage_statistics"
             android:summary="@string/pref_modify_android_usage_summary"


### PR DESCRIPTION
Fixes #17 

- addition of the option to have the searchbar on the bottom
- implementation to have the searchbar on the bottom
- apps scroll to the bottom when the searchbar is on the bottom
- add padding to the user input field so that the software keyboard does not overlay with the searchbar
- searchbar on the bottom works on split screens
- transparent status and navigation bar with icons floating under them

I tested in on a Google Pixel 2, Google Pixel 4 and some Lineage OS phone.