### PR TITLE
Always put DieTask in destroyAllConsumers

### DIFF
--- a/app/src/main/java/com/anpmech/launcher/threading/SimpleTaskConsumerManager.java
+++ b/app/src/main/java/com/anpmech/launcher/threading/SimpleTaskConsumerManager.java
@@ -80,17 +80,17 @@ public class SimpleTaskConsumerManager {
         if (mSubmissionsAccepted) {
             mSubmissionsAccepted = false;
 
-            if (finishCurrentTasks) {
-                final Task dieTask = new DieTask();
-                for (final Thread mThread : mThreads) {
-                    putTask(mTasks, dieTask);
-                }
+            if (!finishCurrentTasks) {
+                mTasks.clear();
+            }
 
-                if (blockUntilFinished) {
-                    blockThreadsUntilFinished();
-                }
-            } else {
-                removeAllTasks();
+            final Task dieTask = new DieTask();
+            for (final Thread mThread : mThreads) {
+                putTask(mTasks, dieTask);
+            }
+
+            if (blockUntilFinished) {
+                blockThreadsUntilFinished();
             }
         }
     }
@@ -105,13 +105,6 @@ public class SimpleTaskConsumerManager {
         destroyAllConsumers(false);
 
         super.finalize();
-    }
-
-    private void removeAllTasks() {
-        for (final Thread thread : mThreads) {
-            thread.interrupt();
-        }
-        mTasks.clear();
     }
 
     public interface Task {


### PR DESCRIPTION
As far as I can tell, this fixes #19. I'm not exactly sure about the mechanism, but it seems like each abandoned thread uses up a small amount of resources (perhaps in the Binder transaction buffer), even if it's not querying the package manager at the time. As the threads accumulate, eventually the package manager is unable to communicate back to the application. This patch makes the threads exit when necessary.