### PR TITLE
Declare QUERY_ALL_PACKAGES permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.anpmech.launcher">
 
+    <uses-permission
+        android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
     <!--
     ~ This permission completely optional and set in the system settings menus. The following
     ~ declares intention to use, if available and granted.


### PR DESCRIPTION
In 6471b54, the API level was bumped from 29 to 30, corresponding to Android 11. One of the changes in this version is that [package visibility is restricted](https://developer.android.com/about/versions/11/privacy/package-visibility). The [documentation](https://developer.android.com/training/basics/intents/package-visibility#all-apps) recommends that the `QUERY_ALL_PACKAGES` permission is included in launcher apps so that they are able to see all other apps.